### PR TITLE
#[allow(missing_docs)] on as_str()

### DIFF
--- a/src/impls/string.rs
+++ b/src/impls/string.rs
@@ -22,6 +22,7 @@ pub fn impl_string(info: &Info) -> proc_macro2::TokenStream {
         }
 
         impl #name {
+            #[allow(missing_docs)]
             pub fn as_str(&self) -> &str {
                 &self.0
             }


### PR DESCRIPTION
If users of this crate have included `#![warn(missing_docs)]` or `#![deny(missing_docs)]` in their projects, `as_str()` will trigger. Fixed.